### PR TITLE
Include LICENSE and README.md in the package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["no-std" ,"algorithms", "cryptography"]
 description= "MagicCrypt is a Java/PHP/NodeJS/Rust library to encrypt/decrpyt strings, files, or data, using Data Encryption Standard(DES) or Advanced Encryption Standard(AES) algorithms. It supports CBC block cipher mode, PKCS5 padding and 64, 128, 192 or 256-bits key length."
 readme = "README.md"
 license = "Apache-2.0"
-include = ["src/**/*", "Cargo.toml"]
+include = ["src/**/*", "Cargo.toml", "LICENSE", "README.md"]
 
 [badges.travis-ci]
 repository = "magiclen/rust-magiccrypt"


### PR DESCRIPTION
Apache-2.0 requires including the license for distribution.

It's good practice to include the README, but not strictly necessary.