### PR TITLE
port to aes 0.7, block-modes 0.8, and des 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ include = ["src/**/*", "Cargo.toml", "README.md", "LICENSE"]
 [dependencies]
 base64 = "0.13"
 digest = "0.9"
-block-modes = "0.7"
-des = "0.6"
-aes-soft = "0.6"
+block-modes = "0.8"
+des = "0.7"
+aes = { version = "0.7", features = ["force-soft"] }
 crc-any = "2.3"
 md-5 = "0.9"
 tiger = "0.1"

--- a/src/ciphers/aes128.rs
+++ b/src/ciphers/aes128.rs
@@ -1,6 +1,6 @@
 extern crate block_modes;
 
-extern crate aes_soft as aes;
+extern crate aes;
 
 extern crate md5;
 
@@ -29,7 +29,7 @@ use block_modes::block_padding::Padding;
 use block_modes::block_padding::Pkcs7;
 use block_modes::{BlockMode, Cbc};
 
-use aes::cipher::block::{Block, Key};
+use aes::cipher::{Block, BlockCipherKey};
 use aes::Aes128;
 
 use md5::Md5;
@@ -42,7 +42,7 @@ const BLOCK_SIZE: usize = 16;
 /// This struct can help you encrypt or decrypt data via AES-128 in a quick way.
 #[derive(Debug, Clone)]
 pub struct MagicCrypt128 {
-    key: Key<Aes128>,
+    key: BlockCipherKey<Aes128>,
     iv: Block<Aes128>,
 }
 

--- a/src/ciphers/aes192.rs
+++ b/src/ciphers/aes192.rs
@@ -1,6 +1,6 @@
 extern crate block_modes;
 
-extern crate aes_soft as aes;
+extern crate aes;
 
 extern crate md5;
 
@@ -31,7 +31,7 @@ use block_modes::block_padding::Padding;
 use block_modes::block_padding::Pkcs7;
 use block_modes::{BlockMode, Cbc};
 
-use aes::cipher::block::{Block, Key};
+use aes::cipher::{Block, BlockCipherKey};
 use aes::Aes192;
 
 use md5::Md5;
@@ -45,7 +45,7 @@ const BLOCK_SIZE: usize = 16;
 /// This struct can help you encrypt or decrypt data via AES-192 in a quick way.
 #[derive(Debug, Clone)]
 pub struct MagicCrypt192 {
-    key: Key<Aes192>,
+    key: BlockCipherKey<Aes192>,
     iv: Block<Aes192>,
 }
 

--- a/src/ciphers/aes256.rs
+++ b/src/ciphers/aes256.rs
@@ -1,6 +1,6 @@
 extern crate block_modes;
 
-extern crate aes_soft as aes;
+extern crate aes;
 
 extern crate md5;
 extern crate sha2;
@@ -30,7 +30,7 @@ use block_modes::block_padding::Padding;
 use block_modes::block_padding::Pkcs7;
 use block_modes::{BlockMode, Cbc};
 
-use aes::cipher::block::{Block, Key};
+use aes::cipher::{Block, BlockCipherKey};
 use aes::Aes256;
 
 use md5::Md5;
@@ -44,7 +44,7 @@ const BLOCK_SIZE: usize = 16;
 /// This struct can help you encrypt or decrypt data via AES-256 in a quick way.
 #[derive(Debug, Clone)]
 pub struct MagicCrypt256 {
-    key: Key<Aes256>,
+    key: BlockCipherKey<Aes256>,
     iv: Block<Aes256>,
 }
 

--- a/src/ciphers/des64.rs
+++ b/src/ciphers/des64.rs
@@ -1,6 +1,6 @@
 extern crate block_modes;
 
-extern crate aes_soft as aes;
+extern crate aes;
 
 extern crate crc_any;
 
@@ -27,7 +27,7 @@ use block_modes::block_padding::Padding;
 use block_modes::block_padding::Pkcs7;
 use block_modes::{BlockMode, Cbc};
 
-use des::cipher::block::{Block, Key};
+use des::cipher::{Block, BlockCipherKey};
 use des::Des;
 
 use crc_any::CRCu64;
@@ -40,7 +40,7 @@ const BLOCK_SIZE: usize = 8;
 /// This struct can help you encrypt or decrypt data via DES-64 in a quick way.
 #[derive(Debug, Clone)]
 pub struct MagicCrypt64 {
-    key: Key<Des>,
+    key: BlockCipherKey<Des>,
     iv: Block<Des>,
 }
 


### PR DESCRIPTION
Port to the latest versions of the RustCrypto crates (aes, block-modes, des).

- `aes-soft` has been deprecated, replaced by `aes` with the `force-soft` feature
- `block` module is no longer public in the reexported `cipher` crate, replace by new public import path
- `cipher::block::Key` has been replaced by `cipher::BlockCipherKey`
