### PR TITLE
Refactor MagicCryptTrait to use byte slice generics

### DIFF
--- a/src/ciphers/aes128.rs
+++ b/src/ciphers/aes128.rs
@@ -37,11 +37,11 @@ pub struct MagicCrypt128 {
 }
 
 impl MagicCryptTrait for MagicCrypt128 {
-    fn new<S: AsRef<str>, V: AsRef<str>>(key: S, iv: Option<V>) -> MagicCrypt128 {
+    fn new<S: AsRef<[u8]>, V: AsRef<[u8]>>(key: S, iv: Option<V>) -> MagicCrypt128 {
         let iv = match iv {
             Some(s) => {
                 let mut hasher = Md5::new();
-                hasher.update(s.as_ref().as_bytes());
+                hasher.update(s.as_ref());
 
                 hasher.finalize()
             },
@@ -50,7 +50,7 @@ impl MagicCryptTrait for MagicCrypt128 {
 
         let key = {
             let mut hasher = Md5::new();
-            hasher.update(key.as_ref().as_bytes());
+            hasher.update(key.as_ref());
 
             hasher.finalize()
         };

--- a/src/ciphers/aes192.rs
+++ b/src/ciphers/aes192.rs
@@ -38,11 +38,11 @@ pub struct MagicCrypt192 {
 }
 
 impl MagicCryptTrait for MagicCrypt192 {
-    fn new<S: AsRef<str>, V: AsRef<str>>(key: S, iv: Option<V>) -> MagicCrypt192 {
+    fn new<S: AsRef<[u8]>, V: AsRef<[u8]>>(key: S, iv: Option<V>) -> MagicCrypt192 {
         let iv = match iv {
             Some(s) => {
                 let mut hasher = Md5::new();
-                hasher.update(s.as_ref().as_bytes());
+                hasher.update(s.as_ref());
 
                 hasher.finalize()
             },
@@ -51,7 +51,7 @@ impl MagicCryptTrait for MagicCrypt192 {
 
         let key = {
             let mut hasher = Tiger::default();
-            hasher.update(key.as_ref().as_bytes());
+            hasher.update(key.as_ref());
 
             hasher.finalize()
         };

--- a/src/ciphers/aes256.rs
+++ b/src/ciphers/aes256.rs
@@ -38,11 +38,11 @@ pub struct MagicCrypt256 {
 }
 
 impl MagicCryptTrait for MagicCrypt256 {
-    fn new<S: AsRef<str>, V: AsRef<str>>(key: S, iv: Option<V>) -> MagicCrypt256 {
+    fn new<S: AsRef<[u8]>, V: AsRef<[u8]>>(key: S, iv: Option<V>) -> MagicCrypt256 {
         let iv = match iv {
             Some(s) => {
                 let mut hasher = Md5::new();
-                hasher.update(s.as_ref().as_bytes());
+                hasher.update(s.as_ref());
 
                 hasher.finalize()
             },
@@ -51,7 +51,7 @@ impl MagicCryptTrait for MagicCrypt256 {
 
         let key = {
             let mut hasher = Sha256::new();
-            hasher.update(key.as_ref().as_bytes());
+            hasher.update(key.as_ref());
 
             hasher.finalize()
         };

--- a/src/ciphers/des64.rs
+++ b/src/ciphers/des64.rs
@@ -36,11 +36,11 @@ pub struct MagicCrypt64 {
 }
 
 impl MagicCryptTrait for MagicCrypt64 {
-    fn new<S: AsRef<str>, V: AsRef<str>>(key: S, iv: Option<V>) -> MagicCrypt64 {
+    fn new<S: AsRef<[u8]>, V: AsRef<[u8]>>(key: S, iv: Option<V>) -> MagicCrypt64 {
         let iv = match iv {
             Some(s) => {
                 let mut hasher = CRCu64::crc64we();
-                hasher.digest(s.as_ref().as_bytes());
+                hasher.digest(s.as_ref());
 
                 GenericArray::clone_from_slice(&hasher.get_crc_vec_be())
             },
@@ -49,7 +49,7 @@ impl MagicCryptTrait for MagicCrypt64 {
 
         let key = {
             let mut hasher = CRCu64::crc64we();
-            hasher.digest(key.as_ref().as_bytes());
+            hasher.digest(key.as_ref());
 
             GenericArray::clone_from_slice(&hasher.get_crc_vec_be())
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ pub struct MagicCrypt {
 
 impl MagicCrypt {
     /// Create a new `MagicCrypt` instance. You may want to use the `new_magic_crypt!` macro.
-    pub fn new<S: AsRef<str>, V: AsRef<str>>(key: S, bit: SecureBit, iv: Option<V>) -> MagicCrypt {
+    pub fn new<S: AsRef<[u8]>, V: AsRef<[u8]>>(key: S, bit: SecureBit, iv: Option<V>) -> MagicCrypt {
         let cipher = match bit {
             SecureBit::Bit64 => MagicCryptCipher::DES64(MagicCrypt64::new(key, iv)),
             SecureBit::Bit128 => MagicCryptCipher::AES128(MagicCrypt128::new(key, iv)),
@@ -132,7 +132,7 @@ impl MagicCrypt {
 
 impl MagicCryptTrait for MagicCrypt {
     #[inline]
-    fn new<S: AsRef<str>, V: AsRef<str>>(key: S, iv: Option<V>) -> MagicCrypt {
+    fn new<S: AsRef<[u8]>, V: AsRef<[u8]>>(key: S, iv: Option<V>) -> MagicCrypt {
         MagicCrypt::new(key, SecureBit::default(), iv)
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -14,7 +14,7 @@ use crate::MagicCryptError;
 
 /// Methods for `MagicCrypt` and `MagicCrypt<bits>` structs.
 pub trait MagicCryptTrait {
-    fn new<S: AsRef<str>, V: AsRef<str>>(key: S, iv: Option<V>) -> Self;
+    fn new<S: AsRef<[u8]>, V: AsRef<[u8]>>(key: S, iv: Option<V>) -> Self;
 
     #[inline]
     fn encrypt_str_to_base64<S: AsRef<str>>(&self, string: S) -> String {


### PR DESCRIPTION
This refactoring enhances the flexibility and robustness of the MagicCrypt constructor by allowing it to handle raw byte slices in addition to strings. 
Handling byte slices directly is more efficient and allows for a broader range of input types, including non-UTF-8 data, which is crucial for such operations.